### PR TITLE
Remove warning about the last seen bug fixed in 0.4

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -33,8 +33,6 @@ body(style="background-color: rgb(238, 238, 238);")
         
         include globalstats.jade
         
-        p(style='color:red') Note! There is a bug in the statistics feature in diaspora* at the moment. This bug causes the active users counts to be less than they should be. Read more <a href="https://github.com/diaspora/diaspora/issues/4734">here</a>.
-        
         p
             em.small Disclaimer: These counts reflect only a part of the network due to the opt-in nature of the statistics.
             


### PR DESCRIPTION
Now that 0.4.1.0 is out, we can remove this warning, most of the pods upgraded already.

You can want to add the 0.4.0.0 milestone to the issue https://github.com/diaspora/diaspora/issues/4734 in the diaspora repository.
