### PR TITLE
Fix daily stats for node counts not excluding long inactive platforms

### DIFF
--- a/thefederation/stats.py
+++ b/thefederation/stats.py
@@ -1,53 +1,20 @@
+import datetime
 import random
+from typing import Dict
 
 from django.template.loader import render_to_string
+from django.utils.timezone import now
 
 from thefederation.models import Stat, Platform
 
 
-def daily_stats():
+def daily_stats() -> str:
     """
     Compile a daily stats post.
 
     :return: str
     """
-    node_counts = Stat.objects.node_counts().order_by('-date')[:30]
-    global_stats = Stat.objects.for_days(days=30)
-
-    platform_users = []
-    for platform in Platform.objects.all():
-        stats = Stat.objects.for_days(days=30, platform=platform.name)
-        if not stats or not stats[0].users_half_year:
-            continue
-        platform_stat = {
-            'name': platform.display_name.replace('.', '．'),
-            'percentage': (stats[0].users_half_year / global_stats[0].users_half_year) * 100,
-            'value': stats[0].users_half_year,
-            'old_value': stats[0].users_half_year - stats[len(stats)-1].users_half_year,
-        }
-        platform_users.append(platform_stat)
-
-    platform_nodes = []
-    for platform in Platform.objects.all():
-        stats = Stat.objects.node_counts(item_type='platform', value=platform.name).order_by('-date')[:30]
-        if not stats:
-            continue
-        platform_stat = {
-            'name': platform.display_name.replace('.', '．'),
-            'percentage': (stats[0]['count'] / node_counts[0]['count']) * 100,
-            'value': stats[0]['count'],
-            'old_value': stats[0]['count'] - stats[len(stats)-1]['count'],
-        }
-        platform_nodes.append(platform_stat)
-
-    context = {
-        'nodes': node_counts[0],
-        'prevnodes': node_counts[len(node_counts)-1],
-        'stat': global_stats[0],
-        'prevstat': global_stats[len(global_stats)-1],
-        'platform_users': platform_users,
-        'platform_nodes': platform_nodes,
-    }
+    context = daily_stats_data()
 
     posts = {
         1: "global_counts",
@@ -57,3 +24,47 @@ def daily_stats():
     post = random.randint(1, 3)
 
     return render_to_string(f'thefederation/social/{posts[post]}.md', context)
+
+
+def daily_stats_data() -> Dict:
+    """
+    Compile daily stats data.
+    """
+    from_date = now().date() - datetime.timedelta(days=30)
+    node_counts = Stat.objects.node_counts(from_date=from_date).order_by('-date')
+    global_stats = Stat.objects.for_days(from_date=from_date)
+    platform_users = []
+    for platform in Platform.objects.all():
+        stats = Stat.objects.for_days(platform=platform.name, from_date=from_date)
+        if not stats or not stats[0].users_half_year:
+            continue
+        platform_stat = {
+            'name': platform.display_name.replace('.', '．'),
+            'percentage': (stats[0].users_half_year / global_stats[0].users_half_year) * 100,
+            'value': stats[0].users_half_year,
+            'change': stats[0].users_half_year - stats[len(stats) - 1].users_half_year,
+        }
+        platform_users.append(platform_stat)
+    platform_nodes = []
+    for platform in Platform.objects.all():
+        stats = Stat.objects.node_counts(
+            item_type='platform', value=platform.name, from_date=from_date,
+        ).order_by('-date')
+        if not stats:
+            continue
+        platform_stat = {
+            'name': platform.display_name.replace('.', '．'),
+            'percentage': (stats[0]['count'] / node_counts[0]['count']) * 100,
+            'value': stats[0]['count'],
+            'change': stats[0]['count'] - stats[len(stats) - 1]['count'],
+        }
+        platform_nodes.append(platform_stat)
+    context = {
+        'nodes': node_counts[0] if node_counts else None,
+        'prevnodes': node_counts[len(node_counts) - 1] if node_counts else None,
+        'stat': global_stats[0] if global_stats else None,
+        'prevstat': global_stats[len(global_stats) - 1] if global_stats else None,
+        'platform_users': platform_users,
+        'platform_nodes': platform_nodes,
+    }
+    return context

--- a/thefederation/templates/thefederation/social/platform_nodes.md
+++ b/thefederation/templates/thefederation/social/platform_nodes.md
@@ -5,7 +5,7 @@
 Total count of nodes per platform and change from 30 days.
 
 {% for platform in platform_nodes|dictsortreversed:"percentage" %}
-* {{ platform.name }}: {{ platform.value }} (share: {{ platform.percentage|floatformat }}%, value change: {{ platform.old_value }}){% endfor %}
+* {{ platform.name }}: {{ platform.value }} (share: {{ platform.percentage|floatformat }}%, value change: {{ platform.change }}){% endfor %}
 
 For more statistics visit [the-federation.info](https://the-federation.info)
 

--- a/thefederation/templates/thefederation/social/platform_users.md
+++ b/thefederation/templates/thefederation/social/platform_users.md
@@ -5,7 +5,7 @@
 Active users per platform and change from 30 days ago.
 
 {% for platform in platform_users|dictsortreversed:"value" %}
-* {{ platform.name }}: {{ platform.value }} (share: {{ platform.percentage|floatformat }}%, value change: {{ platform.old_value }}){% endfor %}
+* {{ platform.name }}: {{ platform.value }} (share: {{ platform.percentage|floatformat }}%, value change: {{ platform.change }}){% endfor %}
 
 For more statistics visit [the-federation.info](https://the-federation.info)
 

--- a/thefederation/tests/factories.py
+++ b/thefederation/tests/factories.py
@@ -48,6 +48,9 @@ class StatFactory(factory.DjangoModelFactory):
     date = now().date()
     node = factory.SubFactory(NodeFactory)
     users_total = factory.Faker('pyint')
+    users_half_year = factory.Faker('pyint')
+    users_monthly = factory.Faker('pyint')
+    users_weekly = factory.Faker('pyint')
 
     class Meta:
         model = Stat

--- a/thefederation/tests/test_stats.py
+++ b/thefederation/tests/test_stats.py
@@ -1,0 +1,94 @@
+import datetime
+
+from django.utils.timezone import now
+from freezegun import freeze_time
+from test_plus import TestCase
+
+from thefederation.models import Stat
+from thefederation.stats import daily_stats, daily_stats_data
+from thefederation.tasks import aggregate_daily_stats
+from thefederation.tests.factories import NodeFactory, StatFactory
+
+
+class DailyStatsDataSingleNodeTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.node = NodeFactory()
+        with freeze_time('2018-03-10'):
+            cls.stat1 = StatFactory(node=cls.node, date=now().date())
+            aggregate_daily_stats()
+        with freeze_time('2018-03-11'):
+            cls.stat2 = StatFactory(node=cls.node, date=now().date())
+            aggregate_daily_stats()
+        with freeze_time('2018-03-12'):
+            cls.stat3 = StatFactory(node=cls.node, date=now().date())
+            aggregate_daily_stats()
+
+    def test_renders(self):
+        daily_stats()
+
+    def test_results(self):
+        with freeze_time('2018-03-12'):
+            stats = daily_stats_data()
+        self.assertEqual(stats['nodes'], {'count': 1, 'date': datetime.date(2018, 3, 12)})
+        self.assertEqual(stats['prevnodes'], {'count': 1, 'date': datetime.date(2018, 3, 10)})
+        self.assertEqual(stats['stat'], Stat.objects.for_global().filter(date=datetime.date(2018, 3, 12)).first())
+        self.assertEqual(stats['prevstat'], Stat.objects.for_global().filter(date=datetime.date(2018, 3, 10)).first())
+        self.assertEqual(
+            stats['platform_users'][0],
+            {
+                'name': self.node.platform.display_name or '',
+                'percentage': 100.0,
+                'value': self.stat3.users_half_year,
+                'change': self.stat3.users_half_year - self.stat1.users_half_year,
+            },
+        )
+        self.assertEqual(
+            stats['platform_nodes'][0],
+            {
+                'name': self.node.platform.display_name or '',
+                'percentage': 100.0,
+                'value': 1,
+                'change': 0,
+            },
+        )
+
+    def test_results__inactive_does_stay_excluded(self):
+        with freeze_time('2018-01-10'):
+            node = NodeFactory()
+            StatFactory(node=node, date=now().date())
+            aggregate_daily_stats()
+
+        with freeze_time('2018-01-11'):
+            StatFactory(node=node, date=now().date())
+            aggregate_daily_stats()
+
+        with freeze_time('2018-01-12'):
+            StatFactory(node=node, date=now().date())
+            aggregate_daily_stats()
+
+        with freeze_time('2018-03-12'):
+            stats = daily_stats_data()
+        self.assertEqual(stats['nodes'], {'count': 1, 'date': datetime.date(2018, 3, 12)})
+        self.assertEqual(stats['prevnodes'], {'count': 1, 'date': datetime.date(2018, 3, 10)})
+        self.assertEqual(stats['stat'], Stat.objects.for_global().filter(date=datetime.date(2018, 3, 12)).first())
+        self.assertEqual(stats['prevstat'], Stat.objects.for_global().filter(date=datetime.date(2018, 3, 10)).first())
+        self.assertEqual(
+            stats['platform_users'][0],
+            {
+                'name': self.node.platform.display_name or '',
+                'percentage': 100.0,
+                'value': self.stat3.users_half_year,
+                'change': self.stat3.users_half_year - self.stat1.users_half_year,
+            },
+        )
+        self.assertEqual(
+            stats['platform_nodes'][0],
+            {
+                'name': self.node.platform.display_name or '',
+                'percentage': 100.0,
+                'value': 1,
+                'change': 0,
+            },
+        )


### PR DESCRIPTION
Refactor a bit the for_days and node_counts QuerySet methods
for Stat model to easier get a date range of stats instances.