### PR TITLE
Allow CORS from anywhere

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -223,6 +223,11 @@ GRAPHENE = {
     'SCHEMA': 'config.schema.schema'
 }
 
+# CORS
+# ----
+# Allow from all
+CORS_ORIGIN_ALLOW_ALL = True
+
 # LOGGING CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#logging

--- a/config/local.py
+++ b/config/local.py
@@ -82,10 +82,3 @@ MIDDLEWARE += ("querycount.middleware.QueryCountMiddleware",)
 if testing:
     # Possibly wont conflict with anything..
     REDIS_DB = 15
-
-# CORS
-# ----
-CORS_ORIGIN_WHITELIST = (
-    "localhost:8080",
-    "127.0.0.1:8080",
-)


### PR DESCRIPTION
This allows developing against the production site data which
is freely available via the GraphQL endpoint without login. Also we
don't care if someone consumes our GraphQL data - that is why we
collect it.