### PR TITLE
Limit all stats GraphQL endpoints by default to 1 year of stats

### DIFF
--- a/thefederation/schema.py
+++ b/thefederation/schema.py
@@ -70,6 +70,8 @@ class StatType(DjangoObjectType):
 
 
 class Query:
+    DEFAULT_PERIOD = '1y'
+
     nodes = graphene.List(
         NodeType,
         host=graphene.String(),
@@ -93,6 +95,7 @@ class Query:
         DateCountType,
         value=graphene.String(),
         itemType=graphene.String(),
+        period=graphene.String(),
     )
     stats_global_today = graphene.Field(
         StatType,
@@ -106,6 +109,7 @@ class Query:
         platform=graphene.String(),
         protocol=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_platform_today = graphene.Field(
         StatType,
@@ -119,57 +123,80 @@ class Query:
         DateFloatCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_users_half_year = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_users_monthly = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_users_per_node = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_users_total = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_users_weekly = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
     stats_local_posts = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
-
     stats_local_comments = graphene.List(
         DateCountType,
         itemType=graphene.String(),
         value=graphene.String(),
+        period=graphene.String(),
     )
 
     @staticmethod
-    def _get_stat_date_counts(stat, value=None, item_type=None):
+    def _get_from_date_from_period(period, date=None):
+        if not date:
+            date = now().date()
+
+        if period.endswith('d'):
+            return date - datetime.timedelta(days=int(period.strip('d')))
+        elif period.endswith('m'):
+            return date - datetime.timedelta(days=int(period.strip('m'))*30)
+        elif period.endswith('y'):
+            return date - datetime.timedelta(days=int(period.strip('y'))*365)
+        raise ValueError('Invalid period, should be for example 5d, 5m or 5y')
+
+    @staticmethod
+    def _get_stat_date_counts(stat, value=None, item_type=None, from_date=None):
+        if not from_date:
+            from_date = Query._get_from_date_from_period(Query.DEFAULT_PERIOD)
+        qs = Stat.objects.filter(date__gte=from_date)
         if value and item_type:
             if item_type == 'platform':
-                qs = Stat.objects.filter(node__platform__name=value)
+                qs = qs.filter(node__platform__name=value)
             elif item_type == 'protocol':
-                qs = Stat.objects.filter(node__protocols__name=value)
+                qs = qs.filter(node__protocols__name=value)
             elif item_type == 'node':
-                qs = Stat.objects.filter(node__host=value)
+                qs = qs.filter(node__host=value)
             else:
                 raise ValueError('itemType should be "platform", "node" or "protocol')
         else:
-            qs = Stat.objects.filter(node__isnull=False)
+            qs = qs.filter(node__isnull=False)
 
         return qs.values('date').annotate(
             count=Sum(stat)
@@ -225,7 +252,7 @@ class Query:
 
     def resolve_stats_counts_nodes(self, info, **kwargs):
         return Stat.objects.node_counts(
-            from_date=now() - datetime.timedelta(days=30),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
             item_type=kwargs.get('itemType'),
             value=kwargs.get('value'),
         ).order_by('-date')
@@ -278,57 +305,83 @@ class Query:
         ).first()
 
     def resolve_stats_users_active_ratio(self, info, **kwargs):
+        qs = Stat.objects.filter(date__gte=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)))
         if kwargs.get('value') and kwargs.get('itemType'):
             if kwargs.get('itemType') == 'platform':
-                qs = Stat.objects.filter(node__platform__name=kwargs.get('value'))
+                qs = qs.filter(node__platform__name=kwargs.get('value'))
             elif kwargs.get('itemType') == 'protocol':
-                qs = Stat.objects.filter(node__protocols__name=kwargs.get('value'))
+                qs = qs.filter(node__protocols__name=kwargs.get('value'))
             elif kwargs.get('itemType') == 'node':
-                qs = Stat.objects.filter(node__host=kwargs.get('value'))
+                qs = qs.filter(node__host=kwargs.get('value'))
             else:
                 raise ValueError('itemType should be "platform", "node" or "protocol')
         else:
-            qs = Stat.objects.filter(node__isnull=False)
+            qs = qs.filter(node__isnull=False)
         return qs.values('date').annotate(
             count=Cast(Sum('users_monthly'), FloatField()) / Cast(Sum('users_total'), FloatField()),
         ).values('date', 'count').order_by('date')
 
     def resolve_stats_users_total(self, info, **kwargs):
-        return Query._get_stat_date_counts('users_total', value=kwargs.get('value'), item_type=kwargs.get('itemType'))
+        return Query._get_stat_date_counts(
+            'users_total',
+            value=kwargs.get('value'),
+            item_type=kwargs.get('itemType'),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
+        )
 
     def resolve_stats_users_half_year(self, info, **kwargs):
         return Query._get_stat_date_counts(
-            'users_half_year', value=kwargs.get('value'), item_type=kwargs.get('itemType')
+            'users_half_year',
+            value=kwargs.get('value'),
+            item_type=kwargs.get('itemType'),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
         )
 
     def resolve_stats_users_monthly(self, info, **kwargs):
         return Query._get_stat_date_counts(
-            'users_monthly', value=kwargs.get('value'), item_type=kwargs.get('itemType')
+            'users_monthly',
+            value=kwargs.get('value'),
+            item_type=kwargs.get('itemType'),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
         )
 
     def resolve_stats_users_per_node(self, info, **kwargs):
+        qs = Stat.objects.filter(date__gte=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)))
         if kwargs.get('value') and kwargs.get('itemType'):
             if kwargs.get('itemType') == 'platform':
-                qs = Stat.objects.filter(node__platform__name=kwargs.get('value'))
+                qs = qs.filter(node__platform__name=kwargs.get('value'))
             elif kwargs.get('itemType') == 'protocol':
-                qs = Stat.objects.filter(node__protocols__name=kwargs.get('value'))
+                qs = qs.filter(node__protocols__name=kwargs.get('value'))
             elif kwargs.get('itemType') == 'node':
-                qs = Stat.objects.filter(node__host=kwargs.get('value'))
+                qs = qs.filter(node__host=kwargs.get('value'))
             else:
                 raise ValueError('itemType should be "platform", "node" or "protocol')
         else:
-            qs = Stat.objects.filter(node__isnull=False)
+            qs = qs.filter(node__isnull=False)
         return qs.values('date').annotate(
             count=Avg('users_total')
         ).values('date', 'count').order_by('date')
 
     def resolve_stats_users_weekly(self, info, **kwargs):
-        return Query._get_stat_date_counts('users_weekly', value=kwargs.get('value'), item_type=kwargs.get('itemType'))
+        return Query._get_stat_date_counts(
+            'users_weekly',
+            value=kwargs.get('value'),
+            item_type=kwargs.get('itemType'),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
+        )
 
     def resolve_stats_local_posts(self, info, **kwargs):
-        return Query._get_stat_date_counts('local_posts', value=kwargs.get('value'), item_type=kwargs.get('itemType'))
+        return Query._get_stat_date_counts(
+            'local_posts',
+            value=kwargs.get('value'),
+            item_type=kwargs.get('itemType'),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
+        )
 
     def resolve_stats_local_comments(self, info, **kwargs):
         return Query._get_stat_date_counts(
-            'local_comments', value=kwargs.get('value'), item_type=kwargs.get('itemType')
+            'local_comments',
+            value=kwargs.get('value'),
+            item_type=kwargs.get('itemType'),
+            from_date=Query._get_from_date_from_period(kwargs.get('period', Query.DEFAULT_PERIOD)),
         )

--- a/thefederation/tests/factories.py
+++ b/thefederation/tests/factories.py
@@ -5,14 +5,14 @@ from thefederation.models import Node, Platform, Protocol, Stat
 
 
 class PlatformFactory(factory.DjangoModelFactory):
-    name = factory.Faker('word')
+    name = factory.Faker('pystr')
 
     class Meta:
         model = Platform
 
 
 class ProtocolFactory(factory.DjangoModelFactory):
-    name = factory.Faker('word')
+    name = factory.Faker('pystr')
 
     class Meta:
         model = Protocol

--- a/thefederation/tests/test_schema.py
+++ b/thefederation/tests/test_schema.py
@@ -63,13 +63,13 @@ class QueryResolveStatsCountsNodes(SchemaTestCase):
 
     def test_contains_result__approx_30_days(self):
         response = self.glient.execute(
-            "query { statsCountsNodes { count }}"
+            'query { statsCountsNodes(period: "30d") { count }}'
         )
         self.assertEqual(len(response['data']['statsCountsNodes']), 31)
 
     def test_contains_result__descending_order(self):
         response = self.glient.execute(
-            "query { statsCountsNodes { count, date }}"
+            'query { statsCountsNodes(period: "30d") { count, date }}'
         )
         self.assertEqual(response['data']['statsCountsNodes'][0]['date'], now().date().isoformat())
         self.assertEqual(


### PR DESCRIPTION
The filter 'period' can be given to specify a custom range. It accepts
any integer + period key 'd' for days, 'm' for months and 'y' for years.