### PR TITLE
Add legacy pods.json route for social-relay

### DIFF
--- a/thefederation/tests/test_views.py
+++ b/thefederation/tests/test_views.py
@@ -1,0 +1,21 @@
+import json
+
+from test_plus import TestCase
+
+from thefederation.tests.factories import NodeFactory
+
+
+class LegacyPodsJsonViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.node = NodeFactory()
+        cls.active_node = NodeFactory(active=True)
+
+    def test_renders(self):
+        self.get('/pods.json')
+        self.response_200()
+        self.assertEqual(
+            json.loads(self.last_response.content),
+            {'pods': [{'host': self.active_node.host}]},
+        )

--- a/thefederation/urls.py
+++ b/thefederation/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
 
-from thefederation.views import register_view, mass_register_view
+from thefederation.views import register_view, mass_register_view, legacy_pods_json_view
 
 urlpatterns = [
     path("massregister/", mass_register_view, name="massregister"),
     path("register/<host>/", register_view),
+
+    # Social-Relay uses this
+    path("pods.json", legacy_pods_json_view, name="pods_json"),
 ]

--- a/thefederation/views.py
+++ b/thefederation/views.py
@@ -1,7 +1,9 @@
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
+from django.http import JsonResponse
 from django.shortcuts import redirect
 
+from thefederation.models import Node
 from thefederation.tasks import poll_node
 from thefederation.utils import is_valid_hostname
 
@@ -37,3 +39,13 @@ def mass_register_view(request):
     messages.info(request, f"Triggered job to register {len(domains)} domains!")
 
     return redirect('admin:app_list', app_label='thefederation')
+
+
+def legacy_pods_json_view(request):
+    """
+    Legacy pods.json route from the old version of this site
+
+    Turns out someone did use it - the Social-Relay. Bring it back until that is rewritten.
+    """
+    nodes = list(Node.objects.active().values('host'))
+    return JsonResponse({'pods': nodes})


### PR DESCRIPTION
We broke relay discovering new nodes when we rewrote. Add the route
back with minimal needed information for now.