### PR TITLE
Improve index page protocols query

### DIFF
--- a/src/components/IndexContent.vue
+++ b/src/components/IndexContent.vue
@@ -224,9 +224,7 @@ const query = gql`
         protocols {
             id
             name
-            nodes {
-              name
-            }
+            activeNodes
         }
         statsGlobalToday {
             usersTotal

--- a/src/components/ProtocolTableRow.vue
+++ b/src/components/ProtocolTableRow.vue
@@ -8,7 +8,7 @@
             </router-link>
         </th>
         <td>
-            {{ protocol.nodes.length }}
+            {{ protocol.activeNodes }}
         </td>
         <td>
             <div v-if="statsProtocolToday">

--- a/thefederation/schema.py
+++ b/thefederation/schema.py
@@ -55,8 +55,13 @@ class PlatformType(DjangoObjectType):
 
 
 class ProtocolType(DjangoObjectType):
+    active_nodes = graphene.Int()
+
     class Meta:
         model = Protocol
+
+    def resolve_active_nodes(self, info):
+        return self.active_nodes
 
 
 class ServiceType(DjangoObjectType):
@@ -85,6 +90,7 @@ class Query:
     protocols = graphene.List(
         ProtocolType,
         name=graphene.String(),
+        activeNodes=graphene.Int(),
     )
     services = graphene.List(
         ServiceType,

--- a/thefederation/tests/fixtures.py
+++ b/thefederation/tests/fixtures.py
@@ -27,3 +27,24 @@ FETCH_NODE_RESPONSE = {
         'local_comments': 6,
     },
 }
+
+FETCH_NODE_RESPONSE__NO_STATS = {
+    'organization': {
+        'account': '',
+        'contact': '',
+        'name': '',
+    },
+    'host': 'example.com',
+    'ip': '127.0.0.1',
+    'name': 'Example',
+    'open_signups': False,
+    'protocols': ["foobar"],
+    'relay': 'all',
+    'server_meta': {},
+    'services': [],
+    'platform': 'barfoo',
+    'version': '1.2.3',
+    'features': {},
+    'country': 'FI',
+    'activity': {},
+}


### PR DESCRIPTION
Don't load a list of node names to determine length. Just load the
active node count.