### PR TITLE
Respond also with json on node registration

### DIFF
--- a/thefederation/views.py
+++ b/thefederation/views.py
@@ -9,12 +9,14 @@ from thefederation.utils import is_valid_hostname
 
 
 def register_view(request, host):
+    json = True if request.content_type == "application/json" else False
     # TODO rate limit this view per caller ip?
-    if not is_valid_hostname:
-        return redirect("/")
-    if poll_node(host):
-        # Success!
+    if is_valid_hostname and poll_node(host):
+        if json:
+            return JsonResponse({'error': None})
         return redirect(f"/node/{host}")
+    if json:
+        return JsonResponse({'error': 'Invalid hostname or broken nodeinfo!'})
     # TODO show an error or something
     return redirect("/")
 


### PR DESCRIPTION
In case someone (me) wants to automate the process you
cannot really tell if it was successful or not since the
current responds is always a JS redirect to somewhere unknown