### PR TITLE
Add safeguards against duplicate nodes

### DIFF
--- a/thefederation/apps.py
+++ b/thefederation/apps.py
@@ -16,6 +16,7 @@ class TheFederationConfig(AppConfig):
 
         from thefederation.social import make_daily_post
         from thefederation.tasks import aggregate_daily_stats
+        from thefederation.tasks import clean_duplicate_nodes
         from thefederation.tasks import poll_nodes
 
         scheduler = django_rq.get_scheduler()
@@ -34,7 +35,11 @@ class TheFederationConfig(AppConfig):
             func=make_daily_post,
             queue_name='high',
         )
-
+        scheduler.cron(
+            '18 4 * * *',
+            func=clean_duplicate_nodes,
+            queue_name='medium',
+        )
         scheduler.schedule(
             scheduled_time=datetime.datetime.utcnow(),
             func=poll_nodes,

--- a/thefederation/management/commands/clean_dupe_nodes.py
+++ b/thefederation/management/commands/clean_dupe_nodes.py
@@ -1,0 +1,25 @@
+import logging
+
+from django.core.management.base import BaseCommand
+from django.db import transaction, IntegrityError
+
+from thefederation.models import Node
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Clean duplicate nodes."
+
+    def handle(self, *args, **options):
+        for node in Node.objects.only('id', 'host').order_by('id'):
+            original = node.host
+
+            try:
+                with transaction.atomic():
+                    # Save, cleaning happens there so invalid hostnames will be caught
+                    node.save()
+            except IntegrityError:
+                # Boom, it's a dupe, delete it
+                logger.info("Deleted duplicate node id %s with hostname %s", node.id, original)
+                node.delete()

--- a/thefederation/models/node.py
+++ b/thefederation/models/node.py
@@ -10,6 +10,7 @@ from enumfields import EnumField
 
 from thefederation.enums import Relay
 from thefederation.models.base import ModelBase
+from thefederation.utils import clean_hostname
 
 __all__ = ('Node',)
 
@@ -45,6 +46,7 @@ class Node(ModelBase):
         return f"{self.name} ({self.host})"
 
     def save(self, *args, **kwargs):
+        self.host = clean_hostname(self.host)
         clean_name = re.match(r'[a-zA-Z]*', self.name)
         if clean_name:
             if self.platform.name == clean_name[0].lower():

--- a/thefederation/tasks.py
+++ b/thefederation/tasks.py
@@ -3,6 +3,7 @@ import random
 import datetime
 import logging
 
+from django.core.management import call_command
 from django.db.models import Sum
 from django.utils.timezone import now
 from django_rq import job
@@ -68,6 +69,16 @@ def aggregate_daily_stats(date=None):
         )
     # Add global stat
     Stat.objects.update_or_create(date=date, protocol=None, platform=None, node=None, defaults=totals)
+
+
+def clean_duplicate_nodes():
+    """
+    Call the clean dupe nodes command.
+    """
+    call_command('clean_dupe_nodes')
+    # Also re-aggregate stats from a few days
+    for single_date in (now().date() - datetime.timedelta(n) for n in range(2)):
+        aggregate_daily_stats(single_date)
 
 
 def fetch_using_method(host, method):

--- a/thefederation/utils.py
+++ b/thefederation/utils.py
@@ -1,7 +1,17 @@
 import re
 
 
-def is_valid_hostname(hostname):
+def clean_hostname(hostname: str) -> str:
+    """
+    Some basic cleaning of a hostname.
+    """
+    hostname = hostname.strip().lower()
+    # Strip protocol
+    hostname = re.sub(r'https?://', '', hostname)
+    return hostname
+
+
+def is_valid_hostname(hostname: str) -> bool:
     """
     Validate is a hostname
 

--- a/thefederation/views.py
+++ b/thefederation/views.py
@@ -5,7 +5,7 @@ from django.shortcuts import redirect
 
 from thefederation.models import Node
 from thefederation.tasks import poll_node
-from thefederation.utils import is_valid_hostname
+from thefederation.utils import is_valid_hostname, clean_hostname
 
 
 def register_view(request, host):
@@ -33,7 +33,8 @@ def mass_register_view(request):
     for line in lines:
         domains += line.split(',')
 
-    domains = {domain.strip() for domain in domains}
+    domains = {clean_hostname(domain) for domain in domains}
+    domains = {domain for domain in domains if is_valid_hostname(domain)}
 
     for domain in domains:
         poll_node.delay(domain)


### PR DESCRIPTION
Ensure hostname is cleaned before trying to register and also on Node.save

Add a cleaning script for dupe nodes.
Even though in theory there shouldn't be more, run it daily just
so that when we make the cleaning process more efficient, the script
will auto-clean current data.

Closes #161 