### PR TITLE
Number formatting for easier reading

### DIFF
--- a/src/assets/stylesheets/home.scss
+++ b/src/assets/stylesheets/home.scss
@@ -1,3 +1,5 @@
+@import 'utils.scss';
+
 .main-header {
   .main-title {
     margin: 2rem;

--- a/src/assets/stylesheets/layout.scss
+++ b/src/assets/stylesheets/layout.scss
@@ -1,3 +1,5 @@
+@import 'utils.scss';
+
 $max-width: 1200px;
 
 #menu {

--- a/src/assets/stylesheets/utils.scss
+++ b/src/assets/stylesheets/utils.scss
@@ -1,3 +1,5 @@
+@import 'flexbox-mixins.scss';
+
 $breakview: 642px;
 $btn-bg: #ddd;
 $btn-text: black;

--- a/src/components/HostingReportPage.vue
+++ b/src/components/HostingReportPage.vue
@@ -34,7 +34,10 @@
                                 </th>
                             </tr>
                         </thead>
-                        <tbody slot="body" slot-scope="sort">
+                        <tbody
+                            slot="body"
+                            slot-scope="sort"
+                        >
                             <tr
                                 v-for="value in sort.values"
                                 :key="value.name"
@@ -93,11 +96,7 @@ export default {
     name: "HostingReportPage",
     components: {ApolloLoader, Drawer, Footer},
 
-    data: () => {
-        return {
-            values: [],
-        }
-    },
+    data: () => ({values: []}),
 }
 </script>
 

--- a/src/components/IndexContent.vue
+++ b/src/components/IndexContent.vue
@@ -9,28 +9,32 @@
                 <div class="col4">
                     <div class="tile valign-wrapper">
                         <ApolloLoader :loading="$apollo.loading">
-                            {{ protocols.length || '' }} <strong>Protocols</strong>
+                            <Number :number="protocols.length" />
+                            <strong>Protocols</strong>
                         </ApolloLoader>
                     </div>
                 </div>
                 <div class="col4">
                     <div class="tile valign-wrapper">
                         <ApolloLoader :loading="$apollo.loading">
-                            {{ platforms.length || '' }} <strong>Projects</strong>
+                            <Number :number="platforms.length" />
+                            <strong>Projects</strong>
                         </ApolloLoader>
                     </div>
                 </div>
                 <div class="col4">
                     <div class="tile valign-wrapper">
                         <ApolloLoader :loading="$apollo.loading">
-                            {{ nodes.length || '' }} <strong>Nodes</strong>
+                            <Number :number="nodes.length" />
+                            <strong>Nodes</strong>
                         </ApolloLoader>
                     </div>
                 </div>
                 <div class="col4">
                     <div class="tile valign-wrapper">
                         <ApolloLoader :loading="$apollo.loading">
-                            {{ statsGlobalToday ? statsGlobalToday.usersTotal : '' }} <strong>Users</strong>
+                            <Number :number="statsGlobalToday ? statsGlobalToday.usersTotal : null" />
+                            <strong>Users</strong>
                         </ApolloLoader>
                     </div>
                 </div>
@@ -63,27 +67,37 @@
                             <ul>
                                 <li>
                                     Nodes:
-                                    <strong>{{ nodes.length || '' }}</strong>
+                                    <strong><Number :number="nodes.length" /></strong>
                                 </li>
                                 <li>
                                     Users:
-                                    <strong>{{ statsGlobalToday ? statsGlobalToday.usersTotal : '' }}</strong>
+                                    <strong>
+                                        <Number :number="statsGlobalToday ? statsGlobalToday.usersTotal : null" />
+                                    </strong>
                                 </li>
                                 <li>
                                     Last 6 months active users:
-                                    <strong>{{ statsGlobalToday ? statsGlobalToday.usersHalfYear : '' }}</strong>
+                                    <strong>
+                                        <Number :number="statsGlobalToday ? statsGlobalToday.usersHalfYear : null" />
+                                    </strong>
                                 </li>
                                 <li>
                                     Last month active users:
-                                    <strong>{{ statsGlobalToday ? statsGlobalToday.usersMonthly : '' }}</strong>
+                                    <strong>
+                                        <Number :number="statsGlobalToday ? statsGlobalToday.usersMonthly : null" />
+                                    </strong>
                                 </li>
                                 <li>
                                     Posts:
-                                    <strong>{{ statsGlobalToday ? statsGlobalToday.localPosts : '' }}</strong>
+                                    <strong>
+                                        <Number :number="statsGlobalToday ? statsGlobalToday.localPosts : null" />
+                                    </strong>
                                 </li>
                                 <li>
                                     Comments:
-                                    <strong>{{ statsGlobalToday ? statsGlobalToday.localComments : '' }}</strong>
+                                    <strong>
+                                        <Number :number="statsGlobalToday ? statsGlobalToday.localComments : null" />
+                                    </strong>
                                 </li>
                             </ul>
                         </ApolloLoader>
@@ -199,6 +213,7 @@ import gql from 'graphql-tag'
 
 import ApolloLoader from "./common/ApolloLoader"
 import Charts from "./Charts"
+import Number from "./common/Number"
 import PlatformTableRow from "./PlatformTableRow"
 import ProtocolTableRow from "./ProtocolTableRow"
 
@@ -251,7 +266,7 @@ export default {
         },
     },
     name: "IndexContent",
-    components: {ApolloLoader, Charts, PlatformTableRow, ProtocolTableRow},
+    components: {ApolloLoader, Charts, PlatformTableRow, ProtocolTableRow, Number},
     data() {
         return {
             nodes: [],

--- a/src/components/PlatformTableRow.vue
+++ b/src/components/PlatformTableRow.vue
@@ -16,12 +16,12 @@
                 {{ platform.displayName ? platform.displayName : platform.name }}
             </router-link>
         </th>
-        <td>
-            {{ nodeCount }}
+        <td class="nodes">
+            <Number :number="nodeCount" />
         </td>
-        <td>
+        <td class="users">
             <div v-if="statsPlatformToday">
-                {{ statsPlatformToday.usersTotal }}
+                <Number :number="statsPlatformToday.usersTotal" />
             </div>
         </td>
         <td>
@@ -49,6 +49,7 @@
 
 <script>
 import gql from 'graphql-tag'
+import Number from './common/Number'
 
 
 const platformStatsQuery = gql`
@@ -71,6 +72,7 @@ export default {
         },
     },
     name: "PlatformTableRow",
+    components: {Number},
     props: {
         platform: {
             type: Object,
@@ -99,3 +101,10 @@ export default {
     },
 }
 </script>
+
+<style scoped>
+    .nodes,
+    .users {
+        text-align: right;
+    }
+</style>

--- a/src/components/ProtocolTableRow.vue
+++ b/src/components/ProtocolTableRow.vue
@@ -7,12 +7,12 @@
                 {{ protocol.name }}
             </router-link>
         </th>
-        <td>
-            {{ protocol.activeNodes }}
+        <td class="nodes">
+            <Number :number="protocol.activeNodes" />
         </td>
-        <td>
+        <td class="users">
             <div v-if="statsProtocolToday">
-                {{ statsProtocolToday.usersTotal }}
+                <Number :number="statsProtocolToday.usersTotal" />
             </div>
         </td>
     </tr>
@@ -20,6 +20,7 @@
 
 <script>
 import gql from 'graphql-tag'
+import Number from './common/Number'
 
 
 const statsQuery = gql`
@@ -42,6 +43,7 @@ export default {
         },
     },
     name: "ProtocolTableRow",
+    components: {Number},
     props: {
         protocol: {
             type: Object,
@@ -55,3 +57,10 @@ export default {
     },
 }
 </script>
+
+<style scoped>
+    .nodes,
+    .users {
+        text-align: right;
+    }
+</style>

--- a/src/components/common/Number.vue
+++ b/src/components/common/Number.vue
@@ -1,0 +1,17 @@
+<template>
+    <span>
+        {{ number ? number.toLocaleString() : ' ' }}
+    </span>
+</template>
+
+<script>
+export default {
+    name: "Number",
+    props: {
+        number: {
+            type: Number,
+            default: null,
+        },
+    },
+}
+</script>


### PR DESCRIPTION
The point of this PR is to add some basic number formatting that would help read particularly large numbers. This is done while respecting the standards for number formatting of the particular language that the visitor's browser is set in."

Here is what it would look like for different visitors having a French or English(US) system:
![screen shot 2019-02-19 at 17 21 10](https://user-images.githubusercontent.com/192539/53051755-e84c4100-346a-11e9-8c95-6097dc632f00.png)

Other commits correct some linting and tests errors found while developing.