### PR TITLE
WIP: Mastodon implemented NodeInfo in 3.0 - prefer that

### DIFF
--- a/thefederation/models/platform.py
+++ b/thefederation/models/platform.py
@@ -68,7 +68,7 @@ class Platform(ModelBase):
             'ganggo': 'nodeinfo',
             'gnusocial': 'nodeinfo',
             'hubzilla': 'nodeinfo' if version >= (1, 6) else "statisticsjson",
-            'mastodon': 'mastodon',
+            'mastodon': 'nodeinfo' if version >= (3, 0, 0) else 'mastodon',
             'misskey': 'misskey',
             'osada': 'nodeinfo',
             'peertube': 'nodeinfo',


### PR DESCRIPTION
This is technically correct but until Mastodon adds more information to their NodeInfo this should not be merged. Currently missing for example the name of the server which is pretty critical for us, and we would like to avoid parsing another document just for the name.