### PR TITLE
Change the order of methods being run on new nodes

### DIFF
--- a/thefederation/tasks.py
+++ b/thefederation/tasks.py
@@ -15,7 +15,7 @@ from thefederation.models import Node, Platform, Protocol, Service, Stat
 
 logger = logging.getLogger(__name__)
 
-METHODS = ['mastodon', 'nodeinfo2', 'nodeinfo', 'matrix', 'misskey', 'statisticsjson']
+METHODS = ['nodeinfo2', 'nodeinfo', 'mastodon', 'matrix', 'misskey', 'statisticsjson']
 
 
 def aggregate_daily_stats(date=None):


### PR DESCRIPTION
Since some platforms implement both mastodon API and nodeinfo,
we want to be sure we always prefer nodeinfo, since otherwise
those servers will be saved as mastodon.