### PR TITLE
Add width to keep icons consistent

### DIFF
--- a/src/components/PlatformTableRow.vue
+++ b/src/components/PlatformTableRow.vue
@@ -6,6 +6,7 @@
                 :alt="platform.name"
                 :title="platform.name"
                 :src="imageSource"
+                :width="1em"
             >
             <div v-else>
 &nbsp;


### PR DESCRIPTION
With the current vue component, the project icons can be a bit ... obtuse.
<img width="1173" alt="image" src="https://github.com/thefederationinfo/the-federation.info/assets/12716395/a5bf9780-9cb7-4e7c-92bd-bdeccfc7ce3e">

This PR makes sure they stay ... uhh .. cute.

Not sure why the [immers space](https://the-federation.info/#:~:text=73-,immers%20space,-8) image is 256x256 instead of 16x16, but this PR is one way to fix it. [The image](https://github.com/thefederationinfo/the-federation.info/blob/main/static/images/immers-space-16.png) could also just be resized.

I set a width of `1em` and that seems to scale well.
